### PR TITLE
Feature #1 Suspend prompt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ def read(fname):
     with open(path, encoding='utf-8') as f:
         return f.read()
 
+
 setup(
     name='with',
     version=__version__,

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -29,21 +29,6 @@ class DescribeGetPrompt(object):
             with pytest.raises(SystemExit):
                 yield from prompt.get_prompt('cmd')
 
-    @pytest.mark.asyncio
-    def it_shows_prompt_again_on_keyboard_interrupt(self):
-        with mock.patch('withtool.prompt.prompt_async') as mock_prompt_async:
-            mock_prompt_async.side_effect = (
-                KeyboardInterrupt,
-                ''
-            )
-
-            try:
-                yield from prompt.get_prompt('cmd')
-            except Exception as e:
-                pytest.fail('It should not have raised: {}'.format(e))
-
-        assert mock_prompt_async.call_count == 2
-
 
 class DescribeGetHistory(object):
 

--- a/withtool/prompt.py
+++ b/withtool/prompt.py
@@ -4,9 +4,16 @@ import sys
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.shortcuts import prompt_async
+from prompt_toolkit.key_binding import manager
+from prompt_toolkit import AbortAction
 from slugify import slugify
 
 from withtool.config import get_config
+
+
+kbmanager = manager.KeyBindingManager.for_prompt()
+registry = kbmanager.registry
+manager.load_basic_system_bindings(registry)
 
 
 def get_prompt(command):
@@ -18,11 +25,10 @@ def get_prompt(command):
             '{}… '.format(command),
             patch_stdout=True,
             history=get_history(config['history_dir'], command),
+            key_bindings_registry=registry,
+            on_abort=AbortAction.RETRY,
             auto_suggest=AutoSuggestFromHistory()
         )
-    except KeyboardInterrupt:
-        yield from get_prompt(command)
-
     except EOFError:
         print('bye')
         sys.exit()


### PR DESCRIPTION
Suspend prompt to run commands while application is in background.

Adds system bindings to allow suspending application in shell with ctrl-z.