### PR TITLE
Upgrade prompt-toolkit to 1.0.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     install_requires=[
         'appdirs==1.4.3',
         'docopt==0.6.2',
-        'prompt-toolkit==1.0',
+        'prompt-toolkit==1.0.13',
         'python-slugify==1.2.3',
     ],
     packages=['withtool'],

--- a/withtool/prompt.py
+++ b/withtool/prompt.py
@@ -1,18 +1,15 @@
 import os
 import sys
 
-from prompt_toolkit import AbortAction
+from prompt_toolkit import AbortAction, key_binding
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.history import FileHistory
-from prompt_toolkit.key_binding import manager
 from prompt_toolkit.shortcuts import prompt_async
-from slugify import slugify
 
+from slugify import slugify
 from withtool.config import get_config
 
-kbmanager = manager.KeyBindingManager.for_prompt()
-registry = kbmanager.registry
-manager.load_basic_system_bindings(registry)
+registry = key_binding.defaults.load_key_bindings_for_prompt()
 
 
 def get_prompt(command):


### PR DESCRIPTION
prompt_toolkit.key_binding.manager is deprecated

Maybe bump version for pip? Is not compatible with prompt-toolkit==1.0.0